### PR TITLE
Add code to enable latent tracing support.

### DIFF
--- a/src/tmg.sh
+++ b/src/tmg.sh
@@ -14,6 +14,12 @@
 
 set -o nounset
 
+TRACING=
+if [ "x$1" = x-t ]; then
+    TRACING=-DTRACING
+    shift
+fi
+
 # What is the input and output files?
 inp_file="$1"
 echo "TMGL file: $inp_file"
@@ -38,7 +44,7 @@ tmgl2="./tmgl2"
 # Determine TMG source and build locations
 build_dir="/tmp/tmg_build"
 tmg_src_dir="$HOME/.local/share/tmg/src"
-if [ ! -d "$tmg_src_dir" ]; then
+if [ -f tmga.c ]; then
     build_dir="build"
     tmg_src_dir="."
 fi
@@ -51,7 +57,7 @@ compile () {
     align="-falign-functions=16"
     opt="-O1"
     while true; do
-        cc -std=c99 "$align" "$opt" tmga.c -o $1
+        cc $TRACING -std=c99 "$align" "$opt" tmga.c -o $1
         if [ $? -eq 0 ]; then
             [ -z "$align" ] && echo "WARNING: functions could not be aligned"
             break

--- a/src/tmga.c
+++ b/src/tmga.c
@@ -514,15 +514,27 @@ int main(int argc, char* argv[]) {
         r1++;
     }
 
+    if (r1 < argc && !strcmp(argv[r1], "-t")) {
+#if TRACING
+        trswitch = true;
+        r1++;
+#else
+	printf("%s not built with tracing enabled\n", argv[0]);
+	exit(1);
+#endif
+    }
+
     // Help message
     if (r1 >= argc || !strcmp(argv[r1], "-h")) {
         printf(SRC_LANGUAGE_ "compiler (%lu-bit)\n", 8*sizeof(tword));
-        printf("Usage: %s [-v] [-h] input [output]\n", argv[0]);
+        printf("Usage: %s [-v] [-h] [-t] input [output]\n", argv[0]);
         printf("\tinput \t- " SRC_LANGUAGE_ "program\n");
         printf("\toutput\t- " DST_LANGUAGE_ "translation\n");
         printf("\t-v    \t- verbose output\n");
         printf("\t-h    \t- display this message and exit\n");
-        
+#if TRACING
+        printf("\t-t    \t- enable tracing\n");
+#endif
         if (verbose) DEBUG("Built with Unix TMG");
 
         return 0;

--- a/src/tmgc.h
+++ b/src/tmgc.h
@@ -14,8 +14,10 @@
 // detailed run-time debugging information.
 #define DEBUG_MODE 1
 
+#ifndef TRACING
 // Original tracing capability; must be set together with trswitch in tmgb.h
 #define TRACING 0
+#endif
 
 // Compile this with more memory than the original code?
 #define MORE_MEMORY


### PR DESCRIPTION
NOTE! trace displays threaded code words in hex, which isn't _especially_ helpful!

src/tmg.sh: if first argument is -t, add -DTRACING to compiles
	use local tmgc.c, if found, in preference to remote
	version from $HOME/.local/share/tmg/src so modified
	local files used when doing tmg development.
src/tmga.c: detect -t (needs to be after -v if both given)
	if binary built with TRACING enabled, set trswitch
	else complain.
src/tmgc.h: only define TRACING as zero if not defined
	(eg from command line)